### PR TITLE
Añadir dependencia con Compendium Folders

### DIFF
--- a/module.json
+++ b/module.json
@@ -12,6 +12,13 @@
   "systems": [
     "dnd5e"
   ],
+  "dependencies": [
+    {
+      "name": "compendium-folders",
+      "manifest": "https://raw.githubusercontent.com/earlSt1/vtt-compendium-folders/082-update/module.json",
+      "version": "2.3.0"
+    }
+  ],
   "packs": [
     {
       "label": "Clases (AelTM)",


### PR DESCRIPTION
Aquí te he añadido la dependencia con Compendium Folders en el manifest, es decir, que cuando instales tu modulo a través del manifest Foundry te avisará de que tiene una dependencia con Compendium Folders.

Saludos.